### PR TITLE
Removed pythonPath as VS Code fixed the bug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,6 @@
                 "projectType": "general",
                 "justMyCode": false,
             },
-            "pythonPath": "python3",
         },
         {
             // This configuration is used to debug the project from its starting point
@@ -40,7 +39,6 @@
                 "projectType": "general",
                 "justMyCode": false,
             },
-            "pythonPath": "python3",
         },
     ]
 }


### PR DESCRIPTION
If the path is still added in the launch.json the debugger will now throw an error and discontinue startup.
The deletion of the mentioned lines provides a fix for #4.